### PR TITLE
Move edit/delete buttons to prevent card duping

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -29,6 +29,12 @@
                             </div>
                         </div>
                     </a>
+                    {% if request.user.is_superuser %}
+                        <small class="ms-3 mt-3">
+                            <a href="{% url 'edit_product' product.id %}">Edit</a> | 
+                            <a class="text-danger" href="{% url 'delete_product' product.id %}">Delete</a>
+                        </small>
+                    {% endif %}
                 </div>
                 {% if forloop.counter|divisibleby:1 %}
                     <div class="col-12 d-sm-none mb-3">

--- a/products/templates/products/products.html
+++ b/products/templates/products/products.html
@@ -51,16 +51,17 @@
                                             {% else %}
                                                 <small class="text-muted">No Rating</small>
                                             {% endif %}
-                                            {% if request.user.is_superuser %}
-                                                <small class="ms-3">
-                                                    <a href="{% url 'edit_product' product.id %}">Edit</a> | 
-                                                    <a class="text-danger" href="{% url 'delete_product' product.id %}">Delete</a>
-                                                </small>
-                                            {% endif %}
+                                            
                                         </div>
                                     </div>
                                 </div>
                             </a>
+                            {% if request.user.is_superuser %}
+                                <small class="ms-3 mt-3">
+                                    <a href="{% url 'edit_product' product.id %}">Edit</a> | 
+                                    <a class="text-danger" href="{% url 'delete_product' product.id %}">Delete</a>
+                                </small>
+                            {% endif %}
                         </div>
                         {% if forloop.counter|divisibleby:1 %}
                             <div class="col-12 d-sm-none mb-3">


### PR DESCRIPTION
Move edit/delete buttons on product page outside of the card a tag.
This prevents a tag duplication and fixes #4 